### PR TITLE
Create table of contents to quickly link to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # Ember BPR Lint
 
-Adds linting rules specific to BPR anti-patterns, including:
+_Adds linting rules specific to BPR anti-patterns._
 
-- Unguarded document references
-- Unguarded window references
-- Unguarded timers
+Table of Contents
+=================
+
+* [Unguarded document references](guides/rules/no-unguarded-document.md#no-unguarded-document-references)
+* [Unguarded window references](guides/rules/no-unguarded-window.md#no-unguarded-window-references-linkedin-specific)
+* [Unguarded timers](guides/rules/no-timers.md#no-timers)


### PR DESCRIPTION
Trying to browse the rules was a little hard to browse via file structure