### PR TITLE
Improve linting logic to handle conditions that contain global references

### DIFF
--- a/lib/utils/bpr.js
+++ b/lib/utils/bpr.js
@@ -1,6 +1,13 @@
 const { get, getParent } = require('../utils/get');
+const EMPTY_CALLEES = Object.freeze([]);
 
-function _getConditions(node) {
+/**
+ * Gets all the callee from a condition.
+ * @param {ASTNode} node
+ * @param {ASTNode} globalReferenceNode
+ * @return {Array}
+ */
+function _getConditions(node, globalReferenceNode) {
   let callees = [];
 
   if (!node.test) {
@@ -11,16 +18,29 @@ function _getConditions(node) {
   _getCallee(node.test, callees);
 
   if (node.test.left) {
+    // If the global reference is part of the conditional and is on the left side (i.e. it's before the
+    // isBrowser check), return an empty array of callees to make isEnvironmentBrowser/isBrowser check false.
+    if (isGlobalBeforeIsBrowser(node, globalReferenceNode)) {
+      return EMPTY_CALLEES;
+    }
     _getCallee(node.test.left, callees);
   }
 
   if (node.test.right) {
+    if (isGlobalAfterOrOperator(node, globalReferenceNode)) {
+      return EMPTY_CALLEES;
+    }
     _getCallee(node.test.right, callees);
   }
 
   return callees;
 }
 
+/**
+ * Function to recursively collect the callees of a given node.
+ * @param {ASTNode} node
+ * @param {Array} callees
+ */
 function _getCallee(node, callees) {
   if (node.callee) {
     callees.push(node.callee);
@@ -34,17 +54,59 @@ function _getCallee(node, callees) {
     _getCallee(node.right, callees);
   }
 }
+/**
+ * Checks whether the global reference node is part of the conditional.
+ * (e.g. `if (isBrowser() && widow.atob())` )
+ * @param {ASTNode} ifStatementNode
+ * @param {ASTNode} globalReferenceNode
+ * @return {Boolean}
+ */
+function isGlobalPartofCondition(ifStatementNode, globalReferenceNode) {
+  return !!getParent(globalReferenceNode, (parentNode) => parentNode === ifStatementNode);
+}
+/**
+ * Checks if the global reference is part of the conditional and is before the isBrowser check.
+ * @param {ASTNode} node
+ * @param {ASTNode} globalReferenceNode
+ * @return {Boolean}
+ */
+function isGlobalBeforeIsBrowser(node, globalReferenceNode) {
+  return isGlobalPartofCondition(node, globalReferenceNode) && node.test.left.object === globalReferenceNode;
+}
+/**
+ * Checks if the global reference is part of the conditional and is after an OR operator (and thus unguarded).
+ * @param {ASTNode} node
+ * @param {ASTNode} globalReferenceNode
+ * @return {Boolean}
+ */
+function isGlobalAfterOrOperator(node, globalReferenceNode) {
+  return isGlobalPartofCondition(node, globalReferenceNode)
+    && node.test.right.object === globalReferenceNode
+    && node.test.operator === '||';
+}
 
-function _isBrowser(node) {
-  let callees = _getConditions(node);
+/**
+ * Gets the IfStatement's callees to determine if any of them are `isBrowser`.
+ * @param {ASTNode} node - IfStatement node
+ * @param {ASTNode} globalReferenceNode - global reference node
+ * @return {Boolean}
+ */
+function _isBrowser(node, globalReferenceNode) {
+  let callees = _getConditions(node, globalReferenceNode);
 
   return callees.some(function(callee) {
     return callee && callee.name === 'isBrowser';
   });
 }
 
-function _isEnvironmentBrowser(node) {
-  let callees = _getConditions(node);
+/**
+ * Gets the IfStatement's callees to determine if any of them are `enviroment.isBrowser`.
+ * @param {ASTNode} node - IfStatement node
+ * @param {ASTNode} globalReferenceNode - global reference node
+ * @return {Boolean}
+ */
+function _isEnvironmentBrowser(node, globalReferenceNode) {
+  let callees = _getConditions(node, globalReferenceNode);
 
   return callees.some(function(callee) {
     let obj = callee.object;
@@ -58,12 +120,23 @@ function isIfStatement(node) {
   return node.type === 'IfStatement';
 }
 
-function isBrowser(node) {
-  return getParent(node, (node) => isIfStatement(node) && _isBrowser(node));
+/**
+ * This function checks if the global reference has a parent which is an IfStatement and whether the global is properly
+ * protected by `isBrowser`.
+ * @param {ASTNode} globalReferenceNode - The node which a global reference
+ * @return {ASTNode}
+ */
+function isBrowser(globalReferenceNode) {
+  return getParent(globalReferenceNode, (node) => isIfStatement(node) && _isBrowser(node, globalReferenceNode));
 }
-
-function isEnvironmentBrowser(node) {
-  return getParent(node, (node) => isIfStatement(node) && _isEnvironmentBrowser(node));
+/**
+ * This function checks if the global reference has a parent which is an IfStatement and whether the global is properly
+ * protected by `enviroment.isBrowser`.
+ * @param {ASTNode} globalReferenceNode - The node which a global reference
+ * @return {ASTNode}
+ */
+function isEnvironmentBrowser(globalReferenceNode) {
+  return getParent(globalReferenceNode, (node) => isIfStatement(node) && _isEnvironmentBrowser(node, globalReferenceNode));
 }
 
 function getEnvironmentImportBinding(node) {

--- a/tests/lib/rules/no-unguarded-globals.js
+++ b/tests/lib/rules/no-unguarded-globals.js
@@ -389,6 +389,56 @@ ruleTester.run('no-unguarded-globals', rule, {
       errors: [{
         message: DOCUMENT_MESSAGE
       }]
+    },
+    {
+      code: `
+        import environment from 'ember-stdlib/utils/environment';
+
+        export default Ember.Component.extend({
+          shortCircuit() {
+            if (environment.isBrowser() && window.localStorage) {
+              return window.localStorage;
+            }
+          }
+        });`
+    },
+    {
+      code: `
+        import environment from 'ember-stdlib/utils/environment';
+        const { isBrowser } = environment
+
+        export default Ember.Component.extend({
+          shortCircuit() {
+            if (isBrowser() && window.localStorage) {
+              return window.localStorage;
+            }
+          }
+        });`
+    },
+    {
+      code: `
+        import environment from 'ember-stdlib/utils/environment';
+
+        export default Ember.Component.extend({
+          isInBrowser() {
+            if (environment.isBrowser() || window) {
+              return true;
+            }
+          }
+        });`
+    },
+    {
+      code: `
+        import environment from 'ember-stdlib/utils/environment';
+        const { isBrowser } = environment;
+
+        export default Ember.Component.extend({
+          isInBrowser() {
+            if (isBrowser() || window) {
+              return true;
+            }
+          }
+        });`
     }
   ],
   invalid: [
@@ -541,6 +591,95 @@ ruleTester.run('no-unguarded-globals', rule, {
             });
           },
         })`,
+      errors: [
+        { message: WINDOW_MESSAGE }
+      ]
+    },
+    {
+      code: `
+        import environment from 'ember-stdlib/utils/environment';
+
+        export default Ember.Component.extend({
+          shortCircuit() {
+            if (environment.isBrowser() || window.localStorage) {
+              return window.localStorage;
+            }
+          }
+        });`,
+      errors: [
+        { message: WINDOW_MESSAGE }
+      ]
+    },
+    {
+      code: `
+        import environment from 'ember-stdlib/utils/environment';
+        const { isBrowser } = environment;
+
+        export default Ember.Component.extend({
+          shortCircuit() {
+            if (isBrowser() || window.localStorage) {
+              return window.localStorage;
+            }
+          }
+        });`,
+      errors: [
+        { message: WINDOW_MESSAGE }
+      ]
+    },
+    {
+      code: `
+        import environment from 'ember-stdlib/utils/environment';
+
+        export default Ember.Component.extend({
+          conditionOrder() {
+            if (window.location && environment.isBrowser()) {
+              doStuff();
+            }
+          }
+        });`,
+      errors: [
+        { message: WINDOW_MESSAGE }
+      ]
+    },
+    {
+      code: `
+        import environment from 'ember-stdlib/utils/environment';
+        const { isBrowser } = environment;
+
+        export default Ember.Component.extend({
+          conditionOrder() {
+            if (window.location && isBrowser()) {
+              doStuff();
+            }
+          }
+        });`,
+      errors: [
+        { message: WINDOW_MESSAGE }
+      ]
+    },
+    {
+      code: `
+        import environment from 'ember-stdlib/utils/environment';
+
+        export default Ember.Component.extend({
+          badFunc() {
+            return environment.isBrowser() || window;
+          }
+        });`,
+      errors: [
+        { message: WINDOW_MESSAGE }
+      ]
+    },
+    {
+      code: `
+        import environment from 'ember-stdlib/utils/environment';
+        const { isBrowser } = environment;
+
+        export default Ember.Component.extend({
+          badFunc() {
+            return isBrowser() || window;
+          }
+        });`,
       errors: [
         { message: WINDOW_MESSAGE }
       ]


### PR DESCRIPTION
Currently, `no-unguarded-globals` will pass all these lines:

```js
// Good
if (isBrowser() && window.location) { ... }

// Bad
if (window.location && isBrowser()) { ... }
if (isBrowser() || window.location)) { ... }
```

**This commit adds**:
* Logic to correctly handle global references in conditions
* Many test cases
* JSDoc comments

Thanks to @nickiaconis for his tests from #10 